### PR TITLE
[DEN-6] WAF - Gets All Custom Rule Sets implementation

### DIFF
--- a/edgecast/waf/custom_rule.go
+++ b/edgecast/waf/custom_rule.go
@@ -1,0 +1,62 @@
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+// Package waf provides an API for managing Web Application Firewall for the EdgeCast CDN.
+// WAF  provides a layer of security between security threats and your external web infrastructure.
+package waf
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type CustomRuleSet struct {
+	//Indicates the system-defined ID for the custom rule set.
+	Id string `json:"id"`
+
+	//Indicates the date and time at which the custom rule was last modified.
+	//Syntax:
+	//MM/DD/YYYYhh:mm:ss [AM|PM]
+	LastModifiedDate shortDateTime `json:"last_modified_date"`
+
+	//Indicates the name of the custom rule set.
+	Name string `json:"name"`
+}
+
+// Used to handle value returned for LastModifiedDate to allow for implementation of UnmarshalJSON below
+type shortDateTime struct {
+	string
+}
+
+//Allows for LastModifiedDate field within customRuleSets struct to be of formatted datetime string
+func (p *shortDateTime) UnmarshalJSON(bytes []byte) error {
+	s := strings.Trim(string(bytes), "\"")
+
+	timeObject, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return fmt.Errorf("GetAllCustomRuleSets: %v", err)
+	}
+
+	p.string = timeObject.Format("1/2/2006 04:04:05 PM")
+	return nil
+}
+
+//Retrieves a list of custom rule sets. A custom rule set allows you to define custom threat assessment criterion.
+func (svc *WAFService) GetAllCustomRuleSets(accountNumber string) ([]CustomRuleSet, error) {
+	url := fmt.Sprintf("/v2/mcc/customers/%s/waf/v1.0/rules", accountNumber)
+
+	request, err := svc.Client.BuildRequest("GET", url, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("GetAllCustomRuleSets: %v", err)
+	}
+
+	var customRuleSets = &[]CustomRuleSet{}
+
+	_, err = svc.Client.SendRequest(request, &customRuleSets)
+
+	if err != nil {
+		return nil, fmt.Errorf("GetAllCustomRuleSets: %v", err)
+	}
+
+	return *customRuleSets, nil
+}

--- a/edgecast/waf/custom_rule.go
+++ b/edgecast/waf/custom_rule.go
@@ -5,8 +5,6 @@ package waf
 
 import (
 	"fmt"
-	"strings"
-	"time"
 )
 
 type CustomRuleSet struct {
@@ -16,28 +14,10 @@ type CustomRuleSet struct {
 	//Indicates the date and time at which the custom rule was last modified.
 	//Syntax:
 	//MM/DD/YYYYhh:mm:ss [AM|PM]
-	LastModifiedDate shortDateTime `json:"last_modified_date"`
+	LastModifiedDate string `json:"last_modified_date"`
 
 	//Indicates the name of the custom rule set.
 	Name string `json:"name"`
-}
-
-// Used to handle value returned for LastModifiedDate to allow for implementation of UnmarshalJSON below
-type shortDateTime struct {
-	string
-}
-
-//Allows for LastModifiedDate field within customRuleSets struct to be of formatted datetime string
-func (p *shortDateTime) UnmarshalJSON(bytes []byte) error {
-	s := strings.Trim(string(bytes), "\"")
-
-	timeObject, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return fmt.Errorf("GetAllCustomRuleSets: %v", err)
-	}
-
-	p.string = timeObject.Format("1/2/2006 04:04:05 PM")
-	return nil
 }
 
 //Retrieves a list of custom rule sets. A custom rule set allows you to define custom threat assessment criterion.

--- a/example/getAllCustomRuleSets.go
+++ b/example/getAllCustomRuleSets.go
@@ -16,6 +16,7 @@ import (
 func main() {
 
 	apiToken := flag.String("api-token", "", "API Token provided to you")
+	accountNumber := flag.String("account-number", "", "Account number you wish to retrieve all Managed Rules for")
 
 	flag.Parse()
 
@@ -29,7 +30,7 @@ func main() {
 	}
 
 	//Get all Custom Rule Sets example
-	customRuleSets, err := wafService.GetAllCustomRuleSets("")
+	customRuleSets, err := wafService.GetAllCustomRuleSets(*accountNumber)
 
 	if err != nil {
 		fmt.Printf("Error retrieving all custom rule sets: %v\n", err)

--- a/example/getAllCustomRuleSets.go
+++ b/example/getAllCustomRuleSets.go
@@ -1,0 +1,42 @@
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license . See LICENSE file in project root for terms.
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/VerizonDigital/ec-sdk-go/edgecast"
+	"github.com/VerizonDigital/ec-sdk-go/edgecast/waf"
+)
+
+// Retrieves a list of custom rule sets
+//
+// Usage:
+// go run getAllCustomRuleSets.go -api-token "<api-token>
+func main() {
+
+	apiToken := flag.String("api-token", "", "API Token provided to you")
+
+	flag.Parse()
+
+	wafConfig := waf.NewConfig(*apiToken)
+	wafConfig.Logger = edgecast.NewStandardLogger()
+	wafService, err := waf.New(wafConfig)
+
+	if err != nil {
+		fmt.Printf("error creating WAF Service: %v\n", err)
+		return
+	}
+
+	//Get all Custom Rule Sets example
+	customRuleSets, err := wafService.GetAllCustomRuleSets("")
+
+	if err != nil {
+		fmt.Printf("Error retrieving all custom rule sets: %v\n", err)
+		return
+	}
+
+	for _, rule := range customRuleSets {
+		fmt.Println(rule)
+	}
+}


### PR DESCRIPTION
Integrates the following WAF API (Get All Custom Rule Sets) into GO Lang SDK

https://dev.vdms.com/cdn/api/index.html#Media_Management/Web-Security/Get-All-Custom-Rule-Sets.htm%3FTocPath%3DWeb%2520Application%2520Firewall%7C_____11