### PR TITLE
[DEN-98] Exponential Backoff with Jitter and special WAF Scopes Retry Policy

### DIFF
--- a/edgecast/client/client.go
+++ b/edgecast/client/client.go
@@ -1,4 +1,5 @@
-// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license . See LICENSE file in project root for terms.
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license.
+// See LICENSE file in project root for terms.
 
 package client
 
@@ -7,15 +8,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/EdgeCast/ec-sdk-go/edgecast/internal/collections"
 	"github.com/EdgeCast/ec-sdk-go/edgecast/internal/jsonutil"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// LiteralResponse is used for unmarshaling response data that is in an unrecognized format
+var (
+	defaultRetryWaitMin = 1 * time.Second
+	defaultRetryWaitMax = 60 * time.Second
+	defaultRetryMax     = 5
+)
+
+// LiteralResponse is used for unmarshaling response data
+// that is in an unrecognized format
 type LiteralResponse struct {
 	Value interface{}
 }
@@ -31,10 +43,26 @@ type Client struct {
 
 // Creates a new client pointing to EdgeCast APIs
 func NewClient(config ClientConfig) Client {
-	// Use PassthroughErrorHandler so that retryablehttp.Client does not obscure API errors
 	httpClient := retryablehttp.NewClient()
 	httpClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	httpClient.Logger = config.Logger
+	httpClient.Backoff = ExponentialJitterBackoff
+
+	if config.RetryWaitMin != nil {
+		httpClient.RetryWaitMin = *config.RetryWaitMin
+	} else {
+		httpClient.RetryWaitMin = defaultRetryWaitMin
+	}
+	if config.RetryWaitMax != nil {
+		httpClient.RetryWaitMax = *config.RetryWaitMax
+	} else {
+		httpClient.RetryWaitMax = defaultRetryWaitMax
+	}
+	if config.RetryMax != nil {
+		httpClient.RetryMax = *config.RetryMax
+	} else {
+		httpClient.RetryMax = defaultRetryMax
+	}
 
 	return Client{
 		HTTPClient: httpClient,
@@ -42,8 +70,13 @@ func NewClient(config ClientConfig) Client {
 	}
 }
 
-// BuildRequest creates a new Request for the Edgecast API, adding appropriate headers
-func (c Client) BuildRequest(method, path string, body interface{}) (*retryablehttp.Request, error) {
+// BuildRequest creates a new Request for the Edgecast API,
+// adding appropriate headers
+func (c Client) BuildRequest(
+	method, path string,
+	body interface{},
+) (*retryablehttp.Request, error) {
+
 	relativeURL, err := url.Parse(path)
 
 	if err != nil {
@@ -64,7 +97,10 @@ func (c Client) BuildRequest(method, path string, body interface{}) (*retryableh
 			if err != nil {
 				return nil, err
 			}
-			logMsg := jsonutil.CreateRequestBodyLogMessage(method, absoluteURL.String(), body)
+			logMsg := jsonutil.CreateRequestBodyLogMessage(
+				method,
+				absoluteURL.String(),
+				body)
 			c.Config.Logger.Debug(logMsg)
 			payload = buf
 
@@ -86,7 +122,8 @@ func (c Client) BuildRequest(method, path string, body interface{}) (*retryableh
 	authHeader, err := c.Config.AuthProvider.GetAuthorizationHeader()
 
 	if err != nil {
-		return nil, fmt.Errorf("BuildRequest: Failed to get authorization: %v", err)
+		return nil,
+			fmt.Errorf("BuildRequest: Failed to get authorization: %v", err)
 	}
 
 	req.Header.Set("Authorization", authHeader)
@@ -95,8 +132,13 @@ func (c Client) BuildRequest(method, path string, body interface{}) (*retryableh
 	return req, nil
 }
 
-// SendRequest sends an HTTP request and, if applicable, sets the response to parsedResponse
-func (c *Client) SendRequest(req *retryablehttp.Request, parsedResponse interface{}) (*http.Response, error) {
+// SendRequest sends an HTTP request and,
+// if applicable, sets the response to parsedResponse
+func (c *Client) SendRequest(
+	req *retryablehttp.Request,
+	parsedResponse interface{},
+) (*http.Response, error) {
+
 	resp, err := c.HTTPClient.Do(req)
 
 	if err != nil {
@@ -127,8 +169,8 @@ func (c *Client) SendRequest(req *retryablehttp.Request, parsedResponse interfac
 	}
 
 	if collections.IsInterfaceArray(f) {
-		if jsonArrayErr := json.Unmarshal([]byte(body), parsedResponse); jsonArrayErr != nil {
-			return nil, fmt.Errorf("malformed Json Array response:%v", jsonArrayErr)
+		if err := json.Unmarshal([]byte(body), parsedResponse); err != nil {
+			return nil, fmt.Errorf("malformed Json Array response:%v", err)
 		}
 	} else {
 		if jsonutil.IsJSONString(bodyAsString) {
@@ -158,8 +200,12 @@ func (c *Client) SendRequest(req *retryablehttp.Request, parsedResponse interfac
 	return resp, nil
 }
 
-// SendRequest sends an HTTP request and, if applicable, sets the response to parsedResponse
-func (c *Client) SendRequestWithStringResponse(req *retryablehttp.Request) (*string, error) {
+// SendRequest sends an HTTP request and,
+// if applicable, sets the response to parsedResponse
+func (c *Client) SendRequestWithStringResponse(
+	req *retryablehttp.Request,
+) (*string, error) {
+
 	resp, err := c.HTTPClient.Do(req)
 
 	if err != nil {
@@ -181,4 +227,48 @@ func (c *Client) SendRequestWithStringResponse(req *retryablehttp.Request) (*str
 	c.Config.Logger.Debug("SendRequest: Response Body: %s", body)
 
 	return &bodyAsString, nil
+}
+
+// ExponentialJitterBackoff calculates exponential backoff, with jitter,
+// based on the attempt number and limited by the provided
+// minimum and maximum durations.
+//
+// It also tries to parse Retry-After response header when a
+// http.StatusTooManyRequests (HTTP Code 429) is found in the resp parameter.
+// Hence it will return the number of seconds the server states it may be
+// ready to process more requests from this client.
+func ExponentialJitterBackoff(
+	min, max time.Duration,
+	attemptNum int,
+	resp *http.Response,
+) time.Duration {
+
+	if resp != nil {
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusServiceUnavailable {
+			if s, ok := resp.Header["Retry-After"]; ok {
+				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+					return time.Second * time.Duration(sleep)
+				}
+			}
+		}
+	}
+
+	// calculate the initial sleep period before jitter
+	// attemptNum starts at 0 so we add 1
+	sleep := math.Pow(2, float64(attemptNum+1)) * float64(min)
+
+	// The final sleep time will be a random number between sleep/2 and sleep
+	sleepWithJitter := sleep/2 + randBetween(0, sleep/2)
+
+	if sleepWithJitter > float64(max) {
+		return max
+	}
+
+	return time.Duration(sleepWithJitter)
+}
+
+func randBetween(min float64, max float64) float64 {
+	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return min + rand.Float64()*(max-min)
 }

--- a/edgecast/client/config.go
+++ b/edgecast/client/config.go
@@ -1,9 +1,11 @@
-// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license.
+// See LICENSE file in project root for terms.
 
 package client
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/EdgeCast/ec-sdk-go/edgecast/auth"
 	"github.com/EdgeCast/ec-sdk-go/edgecast/logging"
@@ -21,4 +23,10 @@ type ClientConfig struct {
 	UserAgent string
 
 	Logger logging.Logger
+
+	RetryWaitMin *time.Duration
+
+	RetryWaitMax *time.Duration
+
+	RetryMax *int
 }

--- a/edgecast/config.go
+++ b/edgecast/config.go
@@ -1,4 +1,5 @@
-// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license.
+// See LICENSE file in project root for terms.
 
 package edgecast
 
@@ -37,10 +38,15 @@ type SDKConfig struct {
 
 	// The User Agent for outgoing HTTP requests
 	UserAgent string
+
+	// Determines whether failed operations should be retried
+	DisableRetry bool
 }
 
-func NewSDKConfig(apiToken string, idsCredentials auth.OAuth2Credentials) SDKConfig {
-
+func NewSDKConfig(
+	apiToken string,
+	idsCredentials auth.OAuth2Credentials,
+) SDKConfig {
 	baseAPIURL, _ := url.Parse(defaultBaseAPIURL)
 	baseAPIURLLegacy, _ := url.Parse(defaultBaseAPIURLLegacy)
 	baseIDSURL, _ := url.Parse(defaultBaseIDSURL)
@@ -53,6 +59,7 @@ func NewSDKConfig(apiToken string, idsCredentials auth.OAuth2Credentials) SDKCon
 		APIToken:         apiToken,
 		IDSCredentials:   idsCredentials,
 		UserAgent:        getDefaultUserAgent(),
+		DisableRetry:     false,
 	}
 }
 

--- a/edgecast/config.go
+++ b/edgecast/config.go
@@ -38,9 +38,6 @@ type SDKConfig struct {
 
 	// The User Agent for outgoing HTTP requests
 	UserAgent string
-
-	// Determines whether failed operations should be retried
-	DisableRetry bool
 }
 
 func NewSDKConfig(
@@ -59,7 +56,6 @@ func NewSDKConfig(
 		APIToken:         apiToken,
 		IDSCredentials:   idsCredentials,
 		UserAgent:        getDefaultUserAgent(),
-		DisableRetry:     false,
 	}
 }
 

--- a/edgecast/waf/scope.go
+++ b/edgecast/waf/scope.go
@@ -174,7 +174,7 @@ type Scope struct {
 		this Security Application Manager configuration and the enforcement
 		action that will be applied to rate limited requests.
 	*/
-	Limits *[]Limit `json:"limits"`
+	Limits *[]Limit `json:"limits,omitempty"`
 
 	/*
 		Describes a URL match condition.
@@ -185,7 +185,7 @@ type Scope struct {
 		Describe the type of action that will take place when
 		the access rule defined within the ACLAuditID property is violated.
 	*/
-	ACLAuditAction *AuditAction `json:"acl_audit_action"`
+	ACLAuditAction *AuditAction `json:"acl_audit_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the access rule that will
@@ -199,7 +199,7 @@ type Scope struct {
 		Describes the type of action that will take place
 		when the access rule defined within the ACLProdID property is violated.
 	*/
-	ACLProdAction *ProdAction `json:"acl_prod_action"`
+	ACLProdAction *ProdAction `json:"acl_prod_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the access rule that will
@@ -219,13 +219,13 @@ type Scope struct {
 		Describes the type of action that will take place
 		when the bots rule defined within the BotsProdID property is violated.
 	*/
-	BotsProdAction *ProdAction `json:"bots_prod_action"`
+	BotsProdAction *ProdAction `json:"bots_prod_action,omitempty"`
 
 	/*
 		Describes the type of action that will take place
 		when the managed rule defined within the ProfileAuditID property is violated.
 	*/
-	ProfileAuditAction *AuditAction `json:"profile_audit_action"`
+	ProfileAuditAction *AuditAction `json:"profile_audit_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the managed rule that will
@@ -239,7 +239,7 @@ type Scope struct {
 		Describes the type of action that will take place
 		when the managed rule defined within the ProfileProdID property is violated.
 	*/
-	ProfileProdAction *ProdAction `json:"profile_prod_action"`
+	ProfileProdAction *ProdAction `json:"profile_prod_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the managed rule that will
@@ -253,7 +253,7 @@ type Scope struct {
 		Describes the type of action that will take place
 		when the custom rule set defined within the RuleAuditID property is violated.
 	*/
-	RuleAuditAction *AuditAction `json:"rules_audit_action"`
+	RuleAuditAction *AuditAction `json:"rules_audit_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the custom rule set that will
@@ -267,7 +267,7 @@ type Scope struct {
 		Describes the type of action that will take place
 		when the custom rule set defined within the RuleProdID property is violated.
 	*/
-	RuleProdAction *ProdAction `json:"rules_prod_action"`
+	RuleProdAction *ProdAction `json:"rules_prod_action,omitempty"`
 
 	/*
 		Indicates the system-defined ID for the custom rule set that will

--- a/edgecast/waf/service.go
+++ b/edgecast/waf/service.go
@@ -1,14 +1,19 @@
-// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+// Copyright Verizon Media, Licensed under the terms of the Apache 2.0 license.
+// See LICENSE file in project root for terms.
 
 package waf
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/EdgeCast/ec-sdk-go/edgecast"
 	"github.com/EdgeCast/ec-sdk-go/edgecast/auth"
 	"github.com/EdgeCast/ec-sdk-go/edgecast/client"
 	"github.com/EdgeCast/ec-sdk-go/edgecast/logging"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // WAF service interacts with the EdgeCast API for WAF
@@ -26,13 +31,37 @@ func New(config edgecast.SDKConfig) (*WAFService, error) {
 		return nil, fmt.Errorf("waf.New(): %v", err)
 	}
 
+	c := client.NewClient(client.ClientConfig{
+		AuthProvider: authProvider,
+		BaseAPIURL:   config.BaseAPIURLLegacy,
+		UserAgent:    config.UserAgent,
+		Logger:       config.Logger,
+	})
+
+	// Special retry policy for WAF Scopes
+	c.HTTPClient.CheckRetry = CheckRetryScopes
+
 	return &WAFService{
-		Client: client.NewClient(client.ClientConfig{
-			AuthProvider: authProvider,
-			BaseAPIURL:   config.BaseAPIURLLegacy,
-			UserAgent:    config.UserAgent,
-			Logger:       config.Logger,
-		}),
+		Client: c,
 		Logger: config.Logger,
 	}, nil
+}
+
+// RetryPolicy provides a callback to check if we
+// will retry on connection errors and server errors.
+func CheckRetryScopes(
+	ctx context.Context,
+	resp *http.Response,
+	err error,
+) (bool, error) {
+
+	// The WAF API throws a 400 Bad Request when the rules
+	// being used for a scope have not been fully processed
+	// We will retry in that situation until a more specific error is provided
+	if resp.StatusCode == http.StatusBadRequest &&
+		resp.Request.Method == "POST" &&
+		strings.Contains(resp.Request.URL.String(), "waf/v1.0/scopes") {
+		return true, nil
+	}
+	return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 }


### PR DESCRIPTION
Not the best way to handle retry for WAF Scopes, but it will work until the API throws a more specific error.